### PR TITLE
Add validation for swipe endpoint requests

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -66,10 +66,84 @@ def swipe():
     Returns:
         Response: JSON response with swipe result and match status.
     """
-    data = request.get_json()
-    user_id = data.get("user_id") if data else None
-    target_id = data.get("target_id") if data else None
-    action = data.get("action") if data else None  # 'like' or 'pass'
+    if not request.is_json:
+        return (
+            jsonify(
+                {
+                    "error": "Invalid request",
+                    "details": "Content type must be application/json.",
+                }
+            ),
+            400,
+        )
+
+    data = request.get_json(silent=True)
+    if data is None:
+        return (
+            jsonify(
+                {
+                    "error": "Invalid request",
+                    "details": "Malformed JSON payload.",
+                }
+            ),
+            400,
+        )
+
+    required_fields = {
+        "user_id": int,
+        "target_id": int,
+        "action": str,
+    }
+
+    for field, expected_type in required_fields.items():
+        if field not in data:
+            return (
+                jsonify(
+                    {
+                        "error": "Invalid request",
+                        "details": f"Missing field '{field}'.",
+                    }
+                ),
+                400,
+            )
+
+        value = data[field]
+        if expected_type is int:
+            if not isinstance(value, int) or isinstance(value, bool):
+                return (
+                    jsonify(
+                        {
+                            "error": "Invalid request",
+                            "details": f"Field '{field}' must be an integer.",
+                        }
+                    ),
+                    400,
+                )
+        elif not isinstance(value, expected_type):
+            return (
+                jsonify(
+                    {
+                        "error": "Invalid request",
+                        "details": f"Field '{field}' must be of type {expected_type.__name__}.",
+                    }
+                ),
+                400,
+            )
+
+    action = data["action"].lower()
+    if action not in {"like", "pass"}:
+        return (
+            jsonify(
+                {
+                    "error": "Invalid request",
+                    "details": "Field 'action' must be either 'like' or 'pass'.",
+                }
+            ),
+            400,
+        )
+
+    user_id = data["user_id"]
+    target_id = data["target_id"]
 
     # Basic match detection logic (to be enhanced with real data)
     is_match = action == "like" and target_id == 101  # Simulation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration to ensure the project root is importable."""
+
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_swipe.py
+++ b/tests/test_swipe.py
@@ -1,0 +1,63 @@
+"""Tests for the /swipe endpoint validations."""
+
+import pytest
+
+from src.main import app
+
+
+@pytest.fixture()
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_swipe_valid_request(client):
+    response = client.post(
+        "/swipe",
+        json={"user_id": 1, "target_id": 101, "action": "like"},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["user_id"] == 1
+    assert body["target_id"] == 101
+    assert body["action"] == "like"
+    assert body["is_match"] is True
+
+
+def test_swipe_missing_field(client):
+    response = client.post(
+        "/swipe",
+        json={"user_id": 1, "action": "like"},
+    )
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["error"] == "Invalid request"
+    assert "Missing field 'target_id'" in body["details"]
+
+
+def test_swipe_invalid_action(client):
+    response = client.post(
+        "/swipe",
+        json={"user_id": 1, "target_id": 202, "action": "superlike"},
+    )
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["error"] == "Invalid request"
+    assert "either 'like' or 'pass'" in body["details"]
+
+
+def test_swipe_non_json_payload(client):
+    response = client.post(
+        "/swipe",
+        data="user_id=1&target_id=2&action=like",
+        content_type="application/x-www-form-urlencoded",
+    )
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["error"] == "Invalid request"
+    assert "application/json" in body["details"]


### PR DESCRIPTION
## Summary
- validate /swipe requests for JSON payloads, required fields, and allowed actions
- add pytest configuration to expose the project root for imports
- cover swipe endpoint with tests for valid and invalid scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d78a5bff2883328d5f247b395a4034