### PR TITLE
Adapt matches endpoint to user-specific responses

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,41 @@ from flask import Flask, jsonify, request
 app = Flask(__name__)
 
 
+MATCHES_BY_USER = {
+    1: [
+        {
+            "id": 1,
+            "user_id": 101,
+            "name": "Sophie Martin",
+            "title": "Product Manager",
+            "company": "TechCorp",
+            "match_score": 85,
+            "common_interests": ["startup", "product", "innovation"],
+        },
+        {
+            "id": 2,
+            "user_id": 102,
+            "name": "Thomas Dubois",
+            "title": "CTO",
+            "company": "InnovateLab",
+            "match_score": 78,
+            "common_interests": ["tech", "leadership", "ai"],
+        },
+    ],
+    2: [
+        {
+            "id": 3,
+            "user_id": 103,
+            "name": "Camille Lefevre",
+            "title": "Data Scientist",
+            "company": "DataWiz",
+            "match_score": 88,
+            "common_interests": ["data", "ai", "cloud"],
+        }
+    ],
+}
+
+
 @app.route("/health")
 def health():
     """Health check endpoint.
@@ -29,26 +64,7 @@ def get_matches(user_id):
     Returns:
         Response: JSON response with user matches and compatibility scores.
     """
-    matches = [
-        {
-            "id": 1,
-            "user_id": 101,
-            "name": "Sophie Martin",
-            "title": "Product Manager",
-            "company": "TechCorp",
-            "match_score": 85,
-            "common_interests": ["startup", "product", "innovation"],
-        },
-        {
-            "id": 2,
-            "user_id": 102,
-            "name": "Thomas Dubois",
-            "title": "CTO",
-            "company": "InnovateLab",
-            "match_score": 78,
-            "common_interests": ["tech", "leadership", "ai"],
-        },
-    ]
+    matches = MATCHES_BY_USER.get(user_id, [])
     return jsonify({"matches": matches, "user_id": user_id})
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest configuration for the matching service tests."""
+
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_matches.py
+++ b/tests/test_matches.py
@@ -1,0 +1,31 @@
+"""Tests for the matches endpoint."""
+
+import pytest
+
+from src.main import app
+
+
+@pytest.fixture()
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as test_client:
+        yield test_client
+
+
+def test_matches_are_user_specific(client):
+    """Ensure each user receives the appropriate match list."""
+
+    response_user_one = client.get("/matches/1")
+    response_user_two = client.get("/matches/2")
+    response_unknown_user = client.get("/matches/999")
+
+    assert response_user_one.status_code == 200
+    assert response_user_two.status_code == 200
+    assert response_unknown_user.status_code == 200
+
+    matches_user_one = response_user_one.get_json()["matches"]
+    matches_user_two = response_user_two.get_json()["matches"]
+    matches_unknown_user = response_unknown_user.get_json()["matches"]
+
+    assert matches_user_one != matches_user_two
+    assert matches_unknown_user == []


### PR DESCRIPTION
## Summary
- adapt the /matches endpoint to return match data keyed by the requested user id
- provide a default empty list when a user has no matches yet
- add tests covering user-specific results and shared pytest configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d78a5de0208332928c89fdf04aa1e1