### PR TITLE
Introduce sqlite-backed storage and integration tests

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,67 @@
+"""Configuration helpers for the matching service."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Runtime configuration loaded from the environment."""
+
+    database_uri: str
+    pool_size: int
+    max_overflow: int
+    pool_timeout: int
+    pool_recycle: int
+    pool_pre_ping: bool
+    max_retries: int
+    retry_backoff: float
+
+    @property
+    def engine_options(self) -> dict[str, object]:
+        """Base keyword arguments used to build the SQLAlchemy engine."""
+
+        return {
+            "pool_size": self.pool_size,
+            "max_overflow": self.max_overflow,
+            "pool_timeout": self.pool_timeout,
+            "pool_recycle": self.pool_recycle,
+            "pool_pre_ping": self.pool_pre_ping,
+            "future": True,
+        }
+
+
+def _to_bool(value: str | None, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "t", "yes", "y"}
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Read settings from environment variables with sensible defaults."""
+
+    return Settings(
+        database_uri=os.getenv(
+            "DATABASE_URI",
+            "postgresql+psycopg://meetinity:meetinity@localhost:5432/meetinity",
+        ),
+        pool_size=int(os.getenv("DATABASE_POOL_SIZE", "5")),
+        max_overflow=int(os.getenv("DATABASE_MAX_OVERFLOW", "10")),
+        pool_timeout=int(os.getenv("DATABASE_POOL_TIMEOUT", "30")),
+        pool_recycle=int(os.getenv("DATABASE_POOL_RECYCLE", "1800")),
+        pool_pre_ping=_to_bool(os.getenv("DATABASE_POOL_PRE_PING"), default=True),
+        max_retries=int(os.getenv("DATABASE_MAX_RETRIES", "3")),
+        retry_backoff=float(os.getenv("DATABASE_RETRY_BACKOFF", "0.5")),
+    )
+
+
+def refresh_settings() -> Settings:
+    """Clear the cached settings so changes to the environment are picked up."""
+
+    get_settings.cache_clear()
+    return get_settings()
+

--- a/src/storage/__init__.py
+++ b/src/storage/__init__.py
@@ -1,0 +1,36 @@
+"""Storage package exposing ORM-like helpers."""
+
+from .database import (
+    count_rows,
+    create_matches,
+    create_swipe,
+    create_user,
+    fetch_matches_for_user,
+    fetch_swipe_events,
+    get_user,
+    has_mutual_like,
+    init_db,
+    log_swipe_event,
+    reset_database,
+)
+from .models import Match, MatchScore, Swipe, SwipeEvent, User
+
+__all__ = [
+    "Match",
+    "MatchScore",
+    "Swipe",
+    "SwipeEvent",
+    "User",
+    "count_rows",
+    "create_matches",
+    "create_swipe",
+    "create_user",
+    "fetch_matches_for_user",
+    "fetch_swipe_events",
+    "get_user",
+    "has_mutual_like",
+    "init_db",
+    "log_swipe_event",
+    "reset_database",
+]
+

--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -1,0 +1,383 @@
+"""Lightweight ORM-like layer backed by sqlite3."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Optional
+
+from src.config import get_settings
+
+from .models import Swipe, SwipeEvent, User
+
+
+_CONNECTION: Optional[sqlite3.Connection] = None
+_LOCK = threading.Lock()
+
+
+def _ensure_parent_directory(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _database_path() -> str:
+    uri = get_settings().database_uri
+    if uri.startswith("sqlite:///"):
+        location = uri[len("sqlite:///") :]
+        if location == ":memory:":
+            return ":memory:"
+        db_path = Path(location)
+        if db_path != Path(":memory:"):
+            _ensure_parent_directory(db_path)
+        return str(db_path)
+    raise RuntimeError(
+        "This lightweight storage layer currently supports only sqlite URIs."
+    )
+
+
+def _connect() -> sqlite3.Connection:
+    global _CONNECTION
+    if _CONNECTION is None:
+        path = _database_path()
+        _CONNECTION = sqlite3.connect(
+            path,
+            check_same_thread=False,
+            detect_types=sqlite3.PARSE_DECLTYPES,
+        )
+        _CONNECTION.row_factory = sqlite3.Row
+        _CONNECTION.execute("PRAGMA foreign_keys = ON")
+    return _CONNECTION
+
+
+def init_db() -> None:
+    """Create database tables if they do not exist."""
+
+    with _LOCK:
+        conn = _connect()
+        cursor = conn.cursor()
+        cursor.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email TEXT NOT NULL UNIQUE,
+                full_name TEXT NOT NULL,
+                title TEXT,
+                company TEXT,
+                bio TEXT,
+                preferences TEXT NOT NULL,
+                is_active INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS swipes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                target_id INTEGER NOT NULL,
+                action TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE,
+                FOREIGN KEY(target_id) REFERENCES users(id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS matches (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                matched_user_id INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                UNIQUE(user_id, matched_user_id),
+                FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE,
+                FOREIGN KEY(matched_user_id) REFERENCES users(id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS match_scores (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                match_id INTEGER NOT NULL UNIQUE,
+                score REAL NOT NULL,
+                details TEXT,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY(match_id) REFERENCES matches(id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS swipe_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                swipe_id INTEGER,
+                event_type TEXT NOT NULL,
+                user_id INTEGER NOT NULL,
+                target_id INTEGER NOT NULL,
+                action TEXT NOT NULL,
+                score REAL,
+                payload TEXT,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY(swipe_id) REFERENCES swipes(id) ON DELETE SET NULL
+            );
+            """
+        )
+        cursor.close()
+
+
+def reset_database() -> None:
+    """Drop and recreate all tables (mainly for tests)."""
+
+    with _LOCK:
+        conn = _connect()
+        cursor = conn.cursor()
+        cursor.executescript(
+            """
+            DROP TABLE IF EXISTS swipe_events;
+            DROP TABLE IF EXISTS match_scores;
+            DROP TABLE IF EXISTS matches;
+            DROP TABLE IF EXISTS swipes;
+            DROP TABLE IF EXISTS users;
+            """
+        )
+        cursor.close()
+    init_db()
+
+
+def _serialize_datetime(value: datetime) -> str:
+    return value.replace(microsecond=0).isoformat()
+
+
+def _now_text() -> str:
+    return _serialize_datetime(datetime.now(UTC))
+
+
+@contextmanager
+def transaction_scope(commit: bool = True) -> Iterator[sqlite3.Cursor]:
+    """Provide a transactional cursor with simple retry logic."""
+
+    settings = get_settings()
+    attempts = max(1, settings.max_retries)
+    delay = settings.retry_backoff
+
+    for attempt in range(attempts):
+        with _LOCK:
+            conn = _connect()
+            cursor = conn.cursor()
+        try:
+            yield cursor
+            if commit:
+                conn.commit()
+            else:
+                conn.rollback()
+            cursor.close()
+            break
+        except sqlite3.OperationalError:
+            cursor.close()
+            conn.rollback()
+            if attempt >= attempts - 1:
+                raise
+            time.sleep(delay)
+            delay *= 2
+        except Exception:
+            cursor.close()
+            conn.rollback()
+            raise
+
+
+def create_user(user: User) -> User:
+    with transaction_scope() as cursor:
+        cursor.execute(
+            """
+            INSERT INTO users (email, full_name, title, company, bio, preferences, is_active, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                user.email,
+                user.full_name,
+                user.title,
+                user.company,
+                user.bio,
+                json.dumps(user.preferences),
+                int(user.is_active),
+                _serialize_datetime(user.created_at),
+                _serialize_datetime(user.updated_at),
+            ),
+        )
+        user.id = cursor.lastrowid
+    return user
+
+
+def get_user(user_id: int) -> Optional[User]:
+    conn = _connect()
+    row = conn.execute("SELECT * FROM users WHERE id = ?", (user_id,)).fetchone()
+    if row is None:
+        return None
+    return User(
+        id=row["id"],
+        email=row["email"],
+        full_name=row["full_name"],
+        title=row["title"],
+        company=row["company"],
+        bio=row["bio"],
+        preferences=json.loads(row["preferences"] or "[]"),
+        is_active=bool(row["is_active"]),
+        created_at=datetime.fromisoformat(row["created_at"]),
+        updated_at=datetime.fromisoformat(row["updated_at"]),
+    )
+
+
+def create_swipe(swipe: Swipe) -> Swipe:
+    with transaction_scope() as cursor:
+        cursor.execute(
+            """
+            INSERT INTO swipes (user_id, target_id, action, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                swipe.user_id,
+                swipe.target_id,
+                swipe.action,
+                _serialize_datetime(swipe.created_at),
+            ),
+        )
+        swipe.id = cursor.lastrowid
+    return swipe
+
+
+def has_mutual_like(user_id: int, target_id: int) -> bool:
+    conn = _connect()
+    row = conn.execute(
+        """
+        SELECT id FROM swipes
+        WHERE user_id = ? AND target_id = ? AND action = 'like'
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        (target_id, user_id),
+    ).fetchone()
+    return row is not None
+
+
+def create_matches(
+    user_id: int,
+    target_id: int,
+    score: float,
+    common_interests: Iterable[str],
+) -> List[int]:
+    details_json = json.dumps({"common_interests": list(common_interests)})
+    created_at = _now_text()
+    match_ids: List[int] = []
+
+    with transaction_scope() as cursor:
+        for left, right in ((user_id, target_id), (target_id, user_id)):
+            cursor.execute(
+                """
+                INSERT OR IGNORE INTO matches (user_id, matched_user_id, created_at)
+                VALUES (?, ?, ?)
+                """,
+                (left, right, created_at),
+            )
+            if cursor.rowcount == 0:
+                existing = cursor.execute(
+                    "SELECT id FROM matches WHERE user_id = ? AND matched_user_id = ?",
+                    (left, right),
+                ).fetchone()
+                match_id = existing["id"]
+            else:
+                match_id = cursor.lastrowid
+            cursor.execute(
+                """
+                INSERT OR REPLACE INTO match_scores (match_id, score, details, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (match_id, score, details_json, created_at),
+            )
+            match_ids.append(match_id)
+    return match_ids
+
+
+def log_swipe_event(event: SwipeEvent) -> SwipeEvent:
+    with transaction_scope() as cursor:
+        cursor.execute(
+            """
+            INSERT INTO swipe_events (swipe_id, event_type, user_id, target_id, action, score, payload, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event.swipe_id,
+                event.event_type,
+                event.user_id,
+                event.target_id,
+                event.action,
+                event.score,
+                json.dumps(event.payload),
+                _serialize_datetime(event.created_at),
+            ),
+        )
+        event.id = cursor.lastrowid
+    return event
+
+
+def fetch_matches_for_user(user_id: int) -> List[Dict[str, object]]:
+    conn = _connect()
+    rows = conn.execute(
+        """
+        SELECT m.id as match_id, m.created_at, u.id as partner_id, u.full_name, u.title, u.company,
+               u.preferences, s.score, s.details
+        FROM matches m
+        LEFT JOIN users u ON u.id = m.matched_user_id
+        LEFT JOIN match_scores s ON s.match_id = m.id
+        WHERE m.user_id = ?
+        ORDER BY m.created_at DESC
+        """,
+        (user_id,),
+    ).fetchall()
+
+    results: List[Dict[str, object]] = []
+    for row in rows:
+        preferences = json.loads(row["preferences"] or "[]") if row["preferences"] else []
+        details = json.loads(row["details"] or "{}") if row["details"] else {}
+        results.append(
+            {
+                "id": row["match_id"],
+                "user_id": row["partner_id"],
+                "name": row["full_name"],
+                "title": row["title"],
+                "company": row["company"],
+                "match_score": row["score"],
+                "preferences": preferences,
+                "common_interests": details.get("common_interests", []),
+                "created_at": row["created_at"],
+            }
+        )
+    return results
+
+
+def count_rows(table: str) -> int:
+    conn = _connect()
+    row = conn.execute(f"SELECT COUNT(*) as count FROM {table}").fetchone()
+    return int(row["count"])
+
+
+def fetch_swipe_events() -> List[Dict[str, object]]:
+    conn = _connect()
+    rows = conn.execute(
+        """
+        SELECT id, swipe_id, event_type, user_id, target_id, action, score, payload, created_at
+        FROM swipe_events
+        ORDER BY id
+        """
+    ).fetchall()
+    events: List[Dict[str, object]] = []
+    for row in rows:
+        events.append(
+            {
+                "id": row["id"],
+                "swipe_id": row["swipe_id"],
+                "event_type": row["event_type"],
+                "user_id": row["user_id"],
+                "target_id": row["target_id"],
+                "action": row["action"],
+                "score": row["score"],
+                "payload": json.loads(row["payload"] or "{}"),
+                "created_at": row["created_at"],
+            }
+        )
+    return events
+

--- a/src/storage/models.py
+++ b/src/storage/models.py
@@ -1,0 +1,75 @@
+"""Dataclass-based models used by the storage layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Dict, List, Optional
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+@dataclass(slots=True)
+class User:
+    """Application user participating in the matching flow."""
+
+    id: Optional[int]
+    email: str
+    full_name: str
+    title: Optional[str] = None
+    company: Optional[str] = None
+    bio: Optional[str] = None
+    preferences: List[str] = field(default_factory=list)
+    is_active: bool = True
+    created_at: datetime = field(default_factory=_utcnow)
+    updated_at: datetime = field(default_factory=_utcnow)
+
+
+@dataclass(slots=True)
+class Swipe:
+    """Individual swipe decision between two users."""
+
+    id: Optional[int]
+    user_id: int
+    target_id: int
+    action: str
+    created_at: datetime = field(default_factory=_utcnow)
+
+
+@dataclass(slots=True)
+class Match:
+    """Represents a match between a user and another profile."""
+
+    id: Optional[int]
+    user_id: int
+    matched_user_id: int
+    created_at: datetime = field(default_factory=_utcnow)
+
+
+@dataclass(slots=True)
+class MatchScore:
+    """Score associated with a specific match."""
+
+    id: Optional[int]
+    match_id: int
+    score: float
+    details: Dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=_utcnow)
+
+
+@dataclass(slots=True)
+class SwipeEvent:
+    """Analytical event recorded for each swipe."""
+
+    id: Optional[int]
+    swipe_id: Optional[int]
+    event_type: str
+    user_id: int
+    target_id: int
+    action: str
+    score: Optional[float] = None
+    payload: Dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=_utcnow)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,30 @@
 """Pytest configuration for the matching service tests."""
 
+import os
 import sys
 from pathlib import Path
 
 
+os.environ.setdefault("DATABASE_URI", "sqlite:///:memory:")
+
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.storage import init_db, reset_database
+
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _initialize_database():
+    init_db()
+    reset_database()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _clean_database():
+    reset_database()
+    yield

--- a/tests/test_swipe.py
+++ b/tests/test_swipe.py
@@ -1,8 +1,16 @@
-"""Tests for the /swipe endpoint validations."""
+"""Tests for the /swipe endpoint validations and persistence."""
 
 import pytest
 
 from src.main import app
+from src.storage import (
+    count_rows,
+    create_swipe,
+    create_user,
+    fetch_matches_for_user,
+    fetch_swipe_events,
+)
+from src.storage.models import Swipe, User
 
 
 @pytest.fixture()
@@ -12,18 +20,66 @@ def client():
         yield c
 
 
-def test_swipe_valid_request(client):
+def _create_users():
+    return (
+        create_user(
+            User(
+                id=None,
+                email="user1@example.com",
+                full_name="User 1",
+                preferences=["ai", "cloud"],
+            )
+        ),
+        create_user(
+            User(
+                id=None,
+                email="user2@example.com",
+                full_name="User 2",
+                preferences=["ai", "robotics"],
+            )
+        ),
+    )
+
+
+def test_swipe_valid_request_creates_records(client):
+    _create_users()
+
     response = client.post(
         "/swipe",
-        json={"user_id": 1, "target_id": 101, "action": "like"},
+        json={"user_id": 1, "target_id": 2, "action": "like"},
     )
 
     assert response.status_code == 200
     body = response.get_json()
-    assert body["user_id"] == 1
-    assert body["target_id"] == 101
-    assert body["action"] == "like"
+    assert body["is_match"] is False
+
+    assert count_rows("swipes") == 1
+    events = fetch_swipe_events()
+    assert len(events) == 1
+    assert events[0]["swipe_id"] == 1
+    assert events[0]["payload"]["user_preferences"] == ["ai", "cloud"]
+
+
+def test_swipe_creates_match_on_mutual_like(client):
+    _create_users()
+    create_swipe(Swipe(id=None, user_id=2, target_id=1, action="like"))
+
+    response = client.post(
+        "/swipe",
+        json={"user_id": 1, "target_id": 2, "action": "like"},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
     assert body["is_match"] is True
+    assert body["match_score"] > 0
+    assert body["common_interests"] == ["ai"]
+
+    matches_user_one = fetch_matches_for_user(1)
+    matches_user_two = fetch_matches_for_user(2)
+    assert len(matches_user_one) == 1
+    assert len(matches_user_two) == 1
+    assert count_rows("match_scores") == 2
 
 
 def test_swipe_missing_field(client):
@@ -41,7 +97,7 @@ def test_swipe_missing_field(client):
 def test_swipe_invalid_action(client):
     response = client.post(
         "/swipe",
-        json={"user_id": 1, "target_id": 202, "action": "superlike"},
+        json={"user_id": 1, "target_id": 2, "action": "superlike"},
     )
 
     assert response.status_code == 400
@@ -61,3 +117,12 @@ def test_swipe_non_json_payload(client):
     body = response.get_json()
     assert body["error"] == "Invalid request"
     assert "application/json" in body["details"]
+
+
+def test_swipe_returns_not_found_for_unknown_user(client):
+    response = client.post(
+        "/swipe",
+        json={"user_id": 999, "target_id": 1, "action": "like"},
+    )
+
+    assert response.status_code == 404

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,0 +1,38 @@
+"""Integration tests validating transactional behaviour."""
+
+import pytest
+
+from src.storage import count_rows, create_user
+from src.storage.database import transaction_scope
+from src.storage.models import User
+
+
+def test_transaction_scope_rolls_back_on_error():
+    """Ensure the transactional context rolls back on raised exceptions."""
+
+    create_user(
+        User(
+            id=None,
+            email="rollback1@example.com",
+            full_name="Rollback One",
+            preferences=["ai"],
+        )
+    )
+    create_user(
+        User(
+            id=None,
+            email="rollback2@example.com",
+            full_name="Rollback Two",
+            preferences=["cloud"],
+        )
+    )
+
+    with pytest.raises(RuntimeError):
+        with transaction_scope() as cursor:
+            cursor.execute(
+                "INSERT INTO swipes (user_id, target_id, action, created_at) VALUES (?, ?, 'like', datetime('now'))",
+                (1, 2),
+            )
+            raise RuntimeError("force rollback")
+
+    assert count_rows("swipes") == 0


### PR DESCRIPTION
## Summary
- add environment-driven database configuration and a lightweight sqlite storage layer with user, swipe, match, and analytics models
- update the Flask routes to persist swipes, matches, scores, and swipe events through the new helpers
- refresh the pytest suite to set up the database and cover persistence and transactional behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9618b21f883329160a992c8098660